### PR TITLE
Add SAN to EDB root certificate

### DIFF
--- a/edb/db/util.go
+++ b/edb/db/util.go
@@ -55,6 +55,7 @@ func createCertificate(commonName string) ([]byte, crypto.PrivateKey) {
 		SerialNumber:          &big.Int{},
 		Subject:               pkix.Name{Organization: []string{"EDB root"}, CommonName: commonName},
 		NotAfter:              time.Now().AddDate(10, 0, 0),
+		DNSNames:              []string{commonName},
 		BasicConstraintsValid: true,
 		IsCA:                  true,
 	}


### PR DESCRIPTION
Fixes integration test for Go 1.15+

Error:
`x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0`