### PR TITLE
AB#882: Capture errors from MariaDB when bootstrapping

### DIFF
--- a/edb/integration_test.go
+++ b/edb/integration_test.go
@@ -188,7 +188,7 @@ func TestPersistence(t *testing.T) {
 	assert.Equal(2., val)
 }
 
-func DisabledTestInvalidQueryInManifest(t *testing.T) { //TODO
+func TestInvalidQueryInManifest(t *testing.T) {
 	assert := assert.New(t)
 
 	cfgFilename := createConfig()
@@ -212,7 +212,7 @@ func DisabledTestInvalidQueryInManifest(t *testing.T) { //TODO
 
 	// DB cannot be started after failed attempt
 	log.SetOutput(ioutil.Discard)
-	assert.Nil(startEDB(cfgFilename))
+	assert.Error(createEdbCmd(cfgFilename).Run())
 	log.SetOutput(os.Stdout)
 }
 
@@ -288,11 +288,7 @@ func cleanupConfig(filename string) {
 }
 
 func startEDB(configFilename string) *os.Process {
-	cmd := exec.Command(*exe, "-c", configFilename)
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid:   true,            // group child with grandchildren so that we can kill 'em all
-		Pdeathsig: syscall.SIGKILL, // kill child if test dies
-	}
+	cmd := createEdbCmd(configFilename)
 	go func() {
 		if *showEdbOutput {
 			cmd.Stdout = os.Stdout
@@ -323,6 +319,15 @@ func startEDB(configFilename string) *os.Process {
 			return cmd.Process
 		}
 	}
+}
+
+func createEdbCmd(configFilename string) *exec.Cmd {
+	cmd := exec.Command(*exe, "-c", configFilename)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid:   true,            // group child with grandchildren so that we can kill 'em all
+		Pdeathsig: syscall.SIGKILL, // kill child if test dies
+	}
+	return cmd
 }
 
 func isUnexpectedEDBError(err error) bool {


### PR DESCRIPTION
(Requires latest Edgeless RT build with: https://github.com/edgelesssys/edgelessrt/commit/32efc60e69aaddd3bc98b223193b5822279ff8eb)

This adds support for MariaDB's error log (which basically just hijacks stdout/stderr and redirects it to a file) and returns error in the manifest query to the user.

Later on when edb is close to release, we can also turn on the `silent-startup` option to turn off the [Note] messages during startup. But for the time being, I would keep it on in case we need to debug something.