### PR TITLE
Fix build on Ubuntu 20.04

### DIFF
--- a/src/stubs.c
+++ b/src/stubs.c
@@ -12,7 +12,7 @@ ERT_STUB(mallinfo, 0)
 ERT_STUB_SILENT(pthread_setname_np, 0)
 ERT_STUB(pthread_yield, -1)
 ERT_STUB(setcontext, -1)
-ERT_STUB(__fdelt_chk, -1)  // disable fortify
+ERT_STUB(__fdelt_chk, 0)
 
 // musl implements POSIX which returns int, but we
 // compile mariadb with glibc which returns char*


### PR DESCRIPTION
This fixes building edb on my local machine, running on Ubuntu 20.04.

Basically redircting fnctl64 to fnctl is needed to get the enclave build running due to Open Enclave / Edgeless RT not implementing fnctl64 directly (if I see this correctly...)?

Same goes for fortify, which is "only" needed to automatically detect buffer overflows. Of course it would be practical to have this integrated, but given that we did not have this integrated so far anyway, this should not be a loss but rather an unadded additional protection. 