### PR TITLE
Replace stub UniqueID with SignerID/ProductID/SecurityVersion

### DIFF
--- a/demo/marblerun-manifest.json
+++ b/demo/marblerun-manifest.json
@@ -2,7 +2,9 @@
     "Packages": {
         "edb": {
             "Debug": true,
-            "UniqueID": "123"
+            "SecurityVersion": 1,
+            "ProductID": 16,
+            "SignerID": "67d7b00741440d29922a15a9ead427b6faf1d610238ae9826da345cea4fee0fe"
         }
     },
     "Marbles": {


### PR DESCRIPTION
Should we also move the file somewhere else, if we so-far only want to reference it in the documentation, but not the demo case itself?