### PR TITLE
clarify quote error consequences; log api listening

### DIFF
--- a/edb/core/core.go
+++ b/edb/core/core.go
@@ -202,7 +202,8 @@ func (c *Core) StartDatabase() error {
 	var err error
 	c.report, err = c.rt.GetRemoteReport(hash[:])
 	if err != nil {
-		fmt.Printf("Failed to get quote: %v\n", err)
+		rt.Log.Printf("Failed to get quote: %v", err)
+		rt.Log.Print("Attestation will not be available.")
 	}
 	return nil
 }

--- a/edb/server/server.go
+++ b/edb/server/server.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 
 	"github.com/edgelesssys/edgelessdb/edb/core"
+	"github.com/edgelesssys/edgelessdb/edb/rt"
 )
 
 type generalResponse struct {
@@ -107,7 +108,8 @@ func RunServer(mux *http.ServeMux, address string, tlsConfig *tls.Config) {
 		TLSConfig: tlsConfig,
 	}
 
-	fmt.Println(server.ListenAndServeTLS("", ""))
+	rt.Log.Println("HTTP REST API listening on", address)
+	rt.Log.Println(server.ListenAndServeTLS("", ""))
 }
 
 func writeJSON(w http.ResponseWriter, v interface{}) {


### PR DESCRIPTION
This should make it clear in simulation mode that a quote error is not fatal and EDB is operational.