### PR TITLE
AB#1139: Deploy manifest from file

### DIFF
--- a/edb/core/config.go
+++ b/edb/core/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	CertificateDNSName string `json:",omitempty"`
 	Debug              bool   `json:",omitempty"`
 	LogDir             string `json:",omitempty"`
+	ManifestFilePath   string `json:",omitempty"`
 }
 
 // EnvDataPath is the name of the optional environment variable holding the data path for edb
@@ -47,6 +48,9 @@ const EnvDebug = "EDG_EDB_DEBUG"
 // EnvLogDir is the name of the optional environment variable holding the path for storing the log files
 const EnvLogDir = "EDG_EDB_LOG_DIR"
 
+// EnvManifestFile holds the path to the manifest file in case we want edb to automatically deploy one
+const EnvManifestFile = "EDG_EDB_MANIFEST_FILE"
+
 // FillConfigFromEnvironment takes an existing config filled with defaults and replaces single values based on environment variables.
 func FillConfigFromEnvironment(config Config) Config {
 	envDataPath := os.Getenv(EnvDataPath)
@@ -55,6 +59,7 @@ func FillConfigFromEnvironment(config Config) Config {
 	envCertificateDNSName := os.Getenv(EnvCertificateDNSName)
 	envDebug := os.Getenv(EnvDebug)
 	envLogDir := os.Getenv(EnvLogDir)
+	envManifestFilePath := os.Getenv(EnvManifestFile)
 
 	if envDataPath != "" {
 		config.DataPath = envDataPath
@@ -79,6 +84,10 @@ func FillConfigFromEnvironment(config Config) Config {
 	if envLogDir != "" {
 		config.LogDir = envLogDir
 		config.Debug = true
+	}
+
+	if envManifestFilePath != "" {
+		config.ManifestFilePath = envManifestFilePath
 	}
 
 	return config

--- a/edb/core/core.go
+++ b/edb/core/core.go
@@ -233,7 +233,13 @@ func (c *Core) StartDatabase() error {
 			color.Yellow(base64.StdEncoding.EncodeToString(encryptedRecoveryData))
 			color.Yellow("-----------------------------------------------------------------------------------------")
 		}
+	} else if dbNotInitializedYet && c.isMarble {
+		color.Red("edb was launched as a Marble, but was not provided a manifest to initialize with.")
+		color.Red("Please make sure your MarbleRun manifest does specify the required environment variable *and* manifest file.")
+		color.Red("For more information: https://docs.edgeless.systems/edgelessdb/#/getting-started/marblerun")
+		return errors.New("marblerun did not supply any manifest")
 	}
+
 	return nil
 }
 

--- a/edb/core/core.go
+++ b/edb/core/core.go
@@ -227,7 +227,7 @@ func (c *Core) StartDatabase() error {
 		if !c.isMarble && len(encryptedRecoveryData) > 0 {
 			color.Yellow("----------------------------------------ATTENTION----------------------------------------")
 			color.Yellow("Store the data below in a safe place to relaunch EdgelessDB on another host machine.")
-			color.Yellow("For more information: https://docs.edgeless.systems/edgelessdb/#/getting-started/recovery")
+			color.Yellow("For more information: https://edglss.cc/doc-edb-recovery")
 			color.Yellow("-----------------------------------------------------------------------------------------")
 			color.Yellow("--------------------------------------RECOVERY DATA--------------------------------------")
 			color.Yellow(base64.StdEncoding.EncodeToString(encryptedRecoveryData))
@@ -236,7 +236,7 @@ func (c *Core) StartDatabase() error {
 	} else if dbNotInitializedYet && c.isMarble {
 		color.Red("edb was launched as a Marble, but was not provided a manifest to initialize with.")
 		color.Red("Please make sure your MarbleRun manifest does specify the required environment variable *and* manifest file.")
-		color.Red("For more information: https://docs.edgeless.systems/edgelessdb/#/getting-started/marblerun")
+		color.Red("For more information: https://edglss.cc/doc-edb-marblerun")
 		return errors.New("marblerun did not supply any manifest")
 	}
 

--- a/edb/db/mariadb.go
+++ b/edb/db/mariadb.go
@@ -55,6 +55,9 @@ const (
 // ErrPreviousInitFailed is thrown when a previous initialization attempt failed, but another init or start is attempted.
 var ErrPreviousInitFailed = errors.New("a previous initialization attempt failed")
 
+// ErrNotInitializedYet is thrown when the database has not been initialized yet
+var ErrNotInitializedYet = errors.New("database has not been initialized yet")
+
 // Mariadbd is used to control mariadbd.
 type Mariadbd interface {
 	Main(cnfPath string) int
@@ -164,7 +167,7 @@ func (d *Mariadb) Start() error {
 	_, err := os.Stat(filepath.Join(d.externalPath, "#rocksdb"))
 	if os.IsNotExist(err) {
 		rt.Log.Println("DB has not been initialized, waiting for manifest.")
-		return nil
+		return ErrNotInitializedYet
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR allows EdgelessDB to automatically deploy a manifest whenever it was launched with "EDG_EDB_MANIFEST_FILE" and a path. The encrypted recovery data is printed to stdout in this case, which theoretically makes it visible to the host... but it's encrypted anyway with a private key unknown to the host (at least if you do not store the private key on the same machine ;)).

For MarbleRun mode, we will actually enforce manifest deployment in this way, as we expect the user to define the initial manifest as part of the MarbleRun manifest to make attestation more reliable & easier.