### PR TITLE
Update pinned libssl-dev version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
   doxygen \
   git \
   liblz4-dev=1.9.2-2ubuntu0.20.04.1 \
-  libssl-dev=1.1.1f-1ubuntu2.4 \
+  libssl-dev=1.1.1f-1ubuntu2.8 \
   ninja-build=1.10.0-1build1 \
   zlib1g-dev=1:1.2.11.dfsg-2ubuntu1.2
 


### PR DESCRIPTION
Update the pinned libssl-dev version from `1.1.1f-1ubuntu2.4` to `1.1.1f-1ubuntu2.8`, since the previous one was removed from the open-ssl repo, resulting in a broken docker image build.

If old versions keep getting removed when newer once are avaiblable, we might want to consider not pinning the version at all.