### PR TITLE
AB#1136: Allow EdgelessDB to recover when sealed_key is missing

### DIFF
--- a/edb/core/key.go
+++ b/edb/core/key.go
@@ -177,10 +177,15 @@ func (c *Core) setMasterKey(key []byte) error {
 }
 
 func (c *Core) mustInitMasterKey() {
+	// Check if RocksDB has already been initialized
+	rocksDBAlreadyInitialized, err := c.fs.Exists(filepath.Join(c.cfg.DataPath, "#rocksdb"))
+	if err != nil {
+		panic(err)
+	}
 	// Try to load from env or file.
 	key, err := c.loadMasterKey()
 	// Does not exist? Generate a new one.
-	if os.IsNotExist(err) {
+	if os.IsNotExist(err) && !rocksDBAlreadyInitialized {
 		key, err = c.newMasterKey()
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Small bug fix where EdgelessDB does not enter recovery mode when sealed_key is deleted but the database has already been initialized.