### PR TITLE
Lower-case chart name

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: EdgelessDB
+name: edgelessdb
 description: EdgelessDB is a MySQL-compatible database for confidential computing. It runs entirely inside a secure enclave and comes with advanced features for collaboration, recovery, and access control. 
 keywords:
 - database


### PR DESCRIPTION
Sorry, noticed this too late, but chart names should be lower-case: https://v2-14-0.helm.sh/docs/chart_best_practices/#chart-names