### PR TITLE
Ref/rdb files

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,21 +1,24 @@
 WarningsAsErrors: '*'
 HeaderFilterRegex: '\.h$'
 Checks: "*,\
+-android-cloexec-fopen,\
 -cert-err58-cpp,\
 -cppcoreguidelines-avoid-goto,\
 -cppcoreguidelines-avoid-magic-numbers,\
 -cppcoreguidelines-owning-memory,\
 -cppcoreguidelines-pro-bounds-array-to-pointer-decay,\
 -cppcoreguidelines-pro-bounds-pointer-arithmetic,\
--cppcoreguidelines-pro-type-cstyle-cast,\
+-cppcoreguidelines-pro-type-const-cast,\
 -cppcoreguidelines-pro-type-reinterpret-cast,\
+-cppcoreguidelines-pro-type-union-access,\
 -cppcoreguidelines-pro-type-vararg,\
 -cppcoreguidelines-special-member-functions,\
 -fuchsia-default-arguments-calls,\
+-fuchsia-default-arguments-declarations,\
 -fuchsia-statically-constructed-objects,\
 -google-build-using-namespace,\
 -google-readability-braces-around-statements,\
--google-readability-casting,\
+-google-runtime-int,\
 -google-readability-todo,\
 -google-runtime-references,\
 -hicpp-avoid-goto,\
@@ -28,10 +31,12 @@ Checks: "*,\
 -llvm-include-order,\
 -llvm-qualified-auto,\
 -misc-non-private-member-variables-in-classes,\
+-modernize-use-nodiscard,\
 -modernize-use-default-member-init,\
 -modernize-use-trailing-return-type,\
 -modernize-use-using,\
 -readability-braces-around-statements,\
 -readability-implicit-bool-conversion,\
+-readability-isolate-declaration,\
 -readability-magic-numbers,\
 -readability-qualified-auto"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,8 +224,10 @@ add_custom_command(OUTPUT x86_64cpuid_.o
 
 add_library(edb-lib
   src/emain.cc
+  src/rocksdb.cc
   src/syscall_file.cc
-  src/syscall_handler.cc)
+  src/syscall_handler.cc
+  src/syscall_hook.cc)
 target_include_directories(edb-lib SYSTEM PRIVATE 3rdparty/edgeless-mariadb/include 3rdparty/edgeless-rocksdb/include)
 target_link_libraries(edb-lib PRIVATE openenclave::oe_includes)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,11 @@ add_custom_command(OUTPUT x86_64cpuid_.o
   DEPENDS x86_64cpuid.o
   COMMAND bbe -e 's/OPENSSL_rdtsc/OPENSSL_rdtsC/' x86_64cpuid.o > x86_64cpuid_.o)
 
-add_library(edb-lib src/emain.cc)
+add_library(edb-lib
+  src/emain.cc
+  src/syscall_file.cc
+  src/syscall_handler.cc)
+target_include_directories(edb-lib SYSTEM PRIVATE 3rdparty/edgeless-mariadb/include 3rdparty/edgeless-rocksdb/include)
 target_link_libraries(edb-lib PRIVATE openenclave::oe_includes)
 
 add_custom_target(edb-golib
@@ -258,8 +262,17 @@ configure_file(src/edb edb COPYONLY)
 #
 
 if(BUILD_TESTS)
+  add_executable(syscall_test
+    src/syscall_test.cc
+    src/syscall_file.cc
+    src/syscall_handler.cc)
+  target_compile_options(syscall_test PRIVATE -fsanitize=address,undefined -fno-sanitize-recover=all)
+  target_link_options(syscall_test PRIVATE -fsanitize=address,undefined)
+  target_link_libraries(syscall_test openenclave::oe_includes)
+
   enable_testing()
   add_test(NAME unit-tests COMMAND go test -race -count=3 ./... WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+  add_test(syscall-test syscall_test)
   add_test(NAME integration-noenclave COMMAND go test -v -tags integration ./edb -e ${CMAKE_BINARY_DIR}/edb-noenclave WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   add_test(NAME integration COMMAND go test -v -tags integration ./edb -e ${CMAKE_BINARY_DIR}/edb -sgx-config ${CMAKE_BINARY_DIR}/edgelessdb-sgx.json WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 endif()

--- a/src/emain.cc
+++ b/src/emain.cc
@@ -28,6 +28,8 @@ using namespace ert;
 static constexpr auto kMemfsName = "edg_memfs";
 
 extern "C" void invokemain();
+extern "C" oe_result_t edgeless_syscall_hook();
+extern "C" void oe_register_syscall_hook(oe_result_t());
 
 int emain() {
   if (oe_load_module_host_epoll() != OE_OK ||
@@ -72,6 +74,8 @@ int emain() {
     cout << "mount hostfs failed\n";
     return EXIT_FAILURE;
   }
+
+  oe_register_syscall_hook(edgeless_syscall_hook);
 
   invokemain();
   return EXIT_SUCCESS;

--- a/src/oe_internal.h
+++ b/src/oe_internal.h
@@ -1,0 +1,75 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <openenclave/bits/result.h>
+#include <openenclave/log.h>
+
+extern "C" oe_result_t oe_log(oe_log_level_t level, const char* fmt, ...);
+
+typedef int64_t oe_host_fd_t;
+typedef int64_t oe_off_t;
+
+enum oe_fd_type_t {
+  OE_FD_TYPE_NONE,
+  OE_FD_TYPE_ANY,
+  OE_FD_TYPE_FILE,
+};
+
+struct oe_fd_t;
+
+/* Common operations on file-descriptor objects. */
+typedef struct _oe_fd_ops {
+  ssize_t (*read)(oe_fd_t* desc, void* buf, size_t count);
+
+  ssize_t (*write)(oe_fd_t* desc, const void* buf, size_t count);
+
+  ssize_t (*readv)(oe_fd_t* desc, const struct oe_iovec* iov, int iovcnt);
+
+  ssize_t (*writev)(oe_fd_t* desc, const struct oe_iovec* iov, int iovcnt);
+
+  int (*flock)(oe_fd_t* desc, int operation);
+
+  int (*dup)(oe_fd_t* desc, oe_fd_t** new_fd);
+
+  int (*ioctl)(oe_fd_t* desc, unsigned long request, uint64_t arg);
+
+  int (*fcntl)(oe_fd_t* desc, int cmd, uint64_t arg);
+
+  int (*close)(oe_fd_t* desc);
+
+  oe_host_fd_t (*get_host_fd)(oe_fd_t* desc);
+} oe_fd_ops_t;
+
+/* File operations. */
+typedef struct _oe_file_ops {
+  /* Inherited operations. */
+  oe_fd_ops_t fd;
+
+  oe_off_t (*lseek)(oe_fd_t* file, oe_off_t offset, int whence);
+
+  ssize_t (*pread)(oe_fd_t* desc, void* buf, size_t count, oe_off_t offset);
+
+  ssize_t (
+      *pwrite)(oe_fd_t* desc, const void* buf, size_t count, oe_off_t offset);
+
+  int (*getdents64)(oe_fd_t* file, struct oe_dirent* dirp, uint32_t count);
+
+  int (*fstat)(oe_fd_t* file, struct oe_stat_t* buf);
+
+  int (*ftruncate)(oe_fd_t* file, oe_off_t length);
+
+  int (*fsync)(oe_fd_t* file);
+  int (*fdatasync)(oe_fd_t* file);
+} oe_file_ops_t;
+
+struct oe_fd_t {
+  oe_fd_type_t type;
+  union {
+    oe_fd_ops_t fd;
+    oe_file_ops_t file;
+  } ops;
+};
+
+extern "C" int oe_fdtable_assign(oe_fd_t* desc);

--- a/src/rocksdb.cc
+++ b/src/rocksdb.cc
@@ -1,0 +1,56 @@
+/* Copyright (c) Edgeless Systems GmbH
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA */
+
+#include "rocksdb.h"
+
+#include <rocksdb/utilities/transaction_db.h>
+
+#include <stdexcept>
+
+// we need to use things from mariadb/storage/rocksdb/ha_rocksdb.cc
+namespace myrocks {
+extern rocksdb::TransactionDB* rdb;
+rocksdb::ColumnFamilyHandle* edgeless_get_column_family(const std::string&);
+}  // namespace myrocks
+
+using namespace std;
+using namespace edb;
+
+static rocksdb::ColumnFamilyHandle* GetCf(string_view name) {
+  const auto cf = myrocks::edgeless_get_column_family(string(name));
+  if (!cf)
+    throw runtime_error("rocksdb: column family not found");
+  return cf;
+}
+
+std::optional<std::string> RocksDB::Get(std::string_view column_family, std::string_view key) const {
+  if (!myrocks::rdb)
+    return {};
+  string value;
+  const auto status = myrocks::rdb->Get({}, GetCf(column_family), key, &value);
+  if (status.ok())
+    return value;
+  if (status.IsNotFound())
+    return {};
+  throw runtime_error("rocksdb: " + status.ToString());
+}
+
+void RocksDB::Put(std::string_view column_family, std::string_view key, std::string_view value) {
+  if (!myrocks::rdb)
+    throw logic_error("rocksdb: put called before store has been initialized");
+  const auto status = myrocks::rdb->Put({}, GetCf(column_family), key, value);
+  if (!status.ok())
+    throw runtime_error("rocksdb: " + status.ToString());
+}

--- a/src/rocksdb.cc
+++ b/src/rocksdb.cc
@@ -54,3 +54,13 @@ void RocksDB::Put(std::string_view column_family, std::string_view key, std::str
   if (!status.ok())
     throw runtime_error("rocksdb: " + status.ToString());
 }
+
+std::vector<std::string> RocksDB::GetKeys(std::string_view column_family, std::string_view prefix) const {
+  if (!myrocks::rdb)
+    return {};
+  const unique_ptr<rocksdb::Iterator> it(myrocks::rdb->NewIterator({}, GetCf(column_family)));
+  vector<string> result;
+  for (it->Seek(prefix); it->Valid() && it->key().starts_with(prefix); it->Next())
+    result.push_back(it->key().ToString());
+  return result;
+}

--- a/src/rocksdb.cc
+++ b/src/rocksdb.cc
@@ -55,6 +55,14 @@ void RocksDB::Put(std::string_view column_family, std::string_view key, std::str
     throw runtime_error("rocksdb: " + status.ToString());
 }
 
+void RocksDB::Delete(std::string_view column_family, std::string_view key) {
+  if (!myrocks::rdb)
+    throw logic_error("rocksdb: delete called before store has been initialized");
+  const auto status = myrocks::rdb->Delete({}, GetCf(column_family), key);
+  if (!status.ok())
+    throw runtime_error("rocksdb: " + status.ToString());
+}
+
 std::vector<std::string> RocksDB::GetKeys(std::string_view column_family, std::string_view prefix) const {
   if (!myrocks::rdb)
     return {};

--- a/src/rocksdb.h
+++ b/src/rocksdb.h
@@ -23,6 +23,7 @@ class RocksDB final : public Store {
  public:
   std::optional<std::string> Get(std::string_view column_family, std::string_view key) const override;
   void Put(std::string_view column_family, std::string_view key, std::string_view value) override;
+  void Delete(std::string_view column_family, std::string_view key) override;
   std::vector<std::string> GetKeys(std::string_view column_family, std::string_view prefix) const override;
 };
 

--- a/src/rocksdb.h
+++ b/src/rocksdb.h
@@ -1,0 +1,28 @@
+/* Copyright (c) Edgeless Systems GmbH
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA */
+
+#pragma once
+
+#include "store.h"
+
+namespace edb {
+
+class RocksDB final : public Store {
+ public:
+  std::optional<std::string> Get(std::string_view column_family, std::string_view key) const override;
+  void Put(std::string_view column_family, std::string_view key, std::string_view value) override;
+};
+
+}  // namespace edb

--- a/src/rocksdb.h
+++ b/src/rocksdb.h
@@ -23,6 +23,7 @@ class RocksDB final : public Store {
  public:
   std::optional<std::string> Get(std::string_view column_family, std::string_view key) const override;
   void Put(std::string_view column_family, std::string_view key, std::string_view value) override;
+  std::vector<std::string> GetKeys(std::string_view column_family, std::string_view prefix) const override;
 };
 
 }  // namespace edb

--- a/src/store.h
+++ b/src/store.h
@@ -28,6 +28,7 @@ class Store {
   virtual ~Store() = default;
   virtual std::optional<std::string> Get(std::string_view column_family, std::string_view key) const = 0;
   virtual void Put(std::string_view column_family, std::string_view key, std::string_view value) = 0;
+  virtual std::vector<std::string> GetKeys(std::string_view column_family, std::string_view prefix) const = 0;
 };
 
 typedef std::shared_ptr<Store> StorePtr;

--- a/src/store.h
+++ b/src/store.h
@@ -28,6 +28,7 @@ class Store {
   virtual ~Store() = default;
   virtual std::optional<std::string> Get(std::string_view column_family, std::string_view key) const = 0;
   virtual void Put(std::string_view column_family, std::string_view key, std::string_view value) = 0;
+  virtual void Delete(std::string_view column_family, std::string_view key) = 0;
   virtual std::vector<std::string> GetKeys(std::string_view column_family, std::string_view prefix) const = 0;
 };
 

--- a/src/store.h
+++ b/src/store.h
@@ -1,0 +1,35 @@
+/* Copyright (c) Edgeless Systems GmbH
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace edb {
+
+class Store {
+ public:
+  virtual ~Store() = default;
+  virtual std::optional<std::string> Get(std::string_view column_family, std::string_view key) const = 0;
+  virtual void Put(std::string_view column_family, std::string_view key, std::string_view value) = 0;
+};
+
+typedef std::shared_ptr<Store> StorePtr;
+
+}  // namespace edb

--- a/src/syscall_file.cc
+++ b/src/syscall_file.cc
@@ -1,0 +1,175 @@
+/* Copyright (c) Edgeless Systems GmbH
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA */
+
+#include "syscall_file.h"
+
+#include <cassert>
+#include <exception>
+#include <functional>
+#include <mutex>
+#include <string>
+
+#include "oe_internal.h"
+
+using namespace std;
+using namespace edb;
+
+namespace edb {
+// can be overridden for testing
+function<decltype(oe_fdtable_assign)> fdtable_assign = oe_fdtable_assign;
+}  // namespace edb
+
+namespace {
+struct File {
+  oe_fd_t base{};
+  string path;
+  mutex mut;
+  size_t offset = 0;
+  SyscallHandler* handler = nullptr;
+};
+}  // namespace
+
+static ssize_t file_read(oe_fd_t* desc, void* buf, size_t count) {
+  try {
+    auto& file = *reinterpret_cast<File*>(desc);
+    const lock_guard lock(file.mut);
+    const size_t res = file.handler->Read(file.path, buf, count, file.offset);
+    file.offset += res;
+    return res;
+  } catch (const exception& ex) {
+    oe_log(OE_LOG_LEVEL_ERROR, "file_read: %s\n", ex.what());
+    errno = EIO;
+    return -1;
+  }
+}
+
+static ssize_t file_write(oe_fd_t* desc, const void* buf, size_t count) {
+  try {
+    auto& file = *reinterpret_cast<File*>(desc);
+    const lock_guard lock(file.mut);
+    file.handler->Write(file.path, string_view(static_cast<const char*>(buf), count), file.offset);
+    file.offset += count;
+    return count;
+  } catch (const exception& ex) {
+    oe_log(OE_LOG_LEVEL_ERROR, "file_write: %s\n", ex.what());
+    errno = EIO;
+    return -1;
+  }
+}
+
+static int file_dup(oe_fd_t* /*desc*/, oe_fd_t** /*new_file_out*/) {
+  errno = ENOSYS;
+  return -1;
+}
+
+static int file_ioctl(oe_fd_t* /*desc*/, unsigned long /*request*/, uint64_t /*arg*/) {
+  errno = ENOSYS;
+  return -1;
+}
+
+static int file_fcntl(oe_fd_t* /*desc*/, int /*cmd*/, uint64_t /*arg*/) {
+  errno = ENOSYS;
+  return -1;
+}
+
+static int file_close(oe_fd_t* desc) {
+  delete reinterpret_cast<File*>(desc);
+  return 0;
+}
+
+static oe_host_fd_t file_get_host_fd(oe_fd_t* /*desc*/) {
+  errno = ENOSYS;
+  return -1;
+}
+
+static oe_off_t file_lseek(oe_fd_t* /*desc*/, oe_off_t /*offset*/, int /*whence*/) {
+  errno = ENOSYS;
+  return -1;
+}
+
+static ssize_t file_pread(
+    oe_fd_t* /*desc*/,
+    void* /*buf*/,
+    size_t /*count*/,
+    oe_off_t /*offset*/) {
+  errno = ENOSYS;
+  return -1;
+}
+
+static ssize_t file_pwrite(
+    oe_fd_t* /*desc*/,
+    const void* /*buf*/,
+    size_t /*count*/,
+    oe_off_t /*offset*/) {
+  errno = ENOSYS;
+  return -1;
+}
+
+static int file_getdents64(
+    oe_fd_t* /*desc*/,
+    struct oe_dirent* /*dirp*/,
+    unsigned int /*count*/) {
+  errno = ENOSYS;
+  return -1;
+}
+
+static int file_fstat(oe_fd_t* /*desc*/, struct oe_stat_t* /*buf*/) {
+  errno = ENOSYS;
+  return -1;
+}
+
+static int file_ftruncate(oe_fd_t* /*desc*/, oe_off_t /*length*/) {
+  errno = ENOSYS;
+  return -1;
+}
+
+static int file_fsync(oe_fd_t* /*desc*/) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int edb::RedirectOpenFile(std::string_view path, SyscallHandler* handler) {
+  assert(!path.empty());
+  assert(handler);
+
+  auto file = make_unique<File>();
+  file->base.type = OE_FD_TYPE_FILE;
+  file->path = path;
+  file->handler = handler;
+
+  auto& ops = file->base.ops;
+  ops.fd.read = file_read;
+  ops.fd.write = file_write;
+  ops.fd.dup = file_dup;
+  ops.fd.ioctl = file_ioctl;
+  ops.fd.fcntl = file_fcntl;
+  ops.fd.close = file_close;
+  ops.fd.get_host_fd = file_get_host_fd;
+  ops.file.lseek = file_lseek;
+  ops.file.pread = file_pread;
+  ops.file.pwrite = file_pwrite;
+  ops.file.getdents64 = file_getdents64;
+  ops.file.fstat = file_fstat;
+  ops.file.ftruncate = file_ftruncate;
+  ops.file.fsync = file_fsync;
+  ops.file.fdatasync = file_fsync;
+
+  const int fd = fdtable_assign(&file->base);
+  if (fd < 0)
+    return -1;
+
+  (void)file.release();
+  return fd;
+}

--- a/src/syscall_file.cc
+++ b/src/syscall_file.cc
@@ -136,8 +136,7 @@ static int file_ftruncate(oe_fd_t* /*desc*/, oe_off_t /*length*/) {
 }
 
 static int file_fsync(oe_fd_t* /*desc*/) {
-  errno = ENOSYS;
-  return -1;
+  return 0;
 }
 
 int edb::RedirectOpenFile(std::string_view path, SyscallHandler* handler) {

--- a/src/syscall_file.h
+++ b/src/syscall_file.h
@@ -1,0 +1,27 @@
+/* Copyright (c) Edgeless Systems GmbH
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA */
+
+#pragma once
+
+#include <string_view>
+
+#include "syscall_handler.h"
+
+namespace edb {
+
+// Opens a file in the enclave runtime and redirects operations on it to handler. Returns an fd.
+int RedirectOpenFile(std::string_view path, SyscallHandler* handler);
+
+}  // namespace edb

--- a/src/syscall_handler.cc
+++ b/src/syscall_handler.cc
@@ -232,8 +232,11 @@ std::optional<int> SyscallHandler::Access(const char* pathname) const {
   const bool known_ext = IsKnownExtension(path);
 
   if (known_ext) {
-    if (!regex_match(path.cbegin(), path.cend(), re_path_to_known_file))
-      throw invalid_argument("unexpected pathname");
+    if (!regex_match(path.cbegin(), path.cend(), re_path_to_known_file)) {
+      path.insert(0, "./");
+      if (!regex_match(path.cbegin(), path.cend(), re_path_to_known_file))
+        throw invalid_argument("unexpected pathname");
+    }
   } else if (regex_match(path.cbegin(), path.cend(), re_folder)) {
     // It might be a db folder. Check if db.opt exists.
     if (path.back() != '/')

--- a/src/syscall_handler.cc
+++ b/src/syscall_handler.cc
@@ -1,0 +1,150 @@
+/* Copyright (c) Edgeless Systems GmbH
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA */
+
+#include "syscall_handler.h"
+
+#include <fcntl.h>
+#include <sys/syscall.h>
+
+#include <cassert>
+#include <cerrno>
+#include <cstring>
+#include <regex>
+#include <stdexcept>
+#include <string>
+
+#include "syscall_file.h"
+
+using namespace std;
+using namespace edb;
+
+static const regex re_folder(R"(\./[^./]+)");
+static const regex re_path_to_known_file(R"(\./[^./]+/(db\.opt|[^./]+\.frm))");
+
+static bool StrEndsWith(string_view str, string_view suffix) {
+  return str.size() >= suffix.size() && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+static bool IsKnownExtension(string_view path) {
+  return StrEndsWith(path, ".frm") || StrEndsWith(path, ".opt");
+}
+
+static string_view GetCf(string_view path) {
+  if (StrEndsWith(path, ".frm"))
+    return kCfNameFrm;
+  if (StrEndsWith(path, ".opt"))
+    return kCfNameDb;
+  throw runtime_error("unexpected path");
+}
+
+SyscallHandler::SyscallHandler(StorePtr store)
+    : store_(move(store)) {
+}
+
+std::optional<int> SyscallHandler::Syscall(long number, long x1, long x2) {
+  switch (number) {
+    case SYS_open:
+      return Open(reinterpret_cast<char*>(x1), static_cast<int>(x2));
+    case SYS_access:
+      return Access(reinterpret_cast<char*>(x1));
+    default:
+      return {};
+  }
+}
+
+size_t SyscallHandler::Read(std::string_view path, void* buf, size_t count, size_t offset) const {
+  const string_view cf = GetCf(path);
+  optional<string> value;
+
+  {
+    const lock_guard lock(mutex_);
+    value = store_->Get(cf, path);
+  }
+
+  if (!value)
+    throw logic_error("not found");
+
+  if (value->size() <= offset)
+    return 0;
+
+  count = min(count, value->size() - offset);
+  memcpy(buf, value->data() + offset, count);
+  return count;
+}
+
+void SyscallHandler::Write(std::string_view path, std::string_view buf, size_t offset) {
+  const string_view cf = GetCf(path);
+
+  const lock_guard lock(mutex_);
+
+  string value = store_->Get(cf, path).value_or(string());
+
+  const size_t required_size = offset + buf.size();
+  if (required_size < offset)
+    throw overflow_error("write offset overflow");
+  if (value.size() < required_size)
+    value.resize(required_size);
+
+  memcpy(value.data() + offset, buf.data(), buf.size());
+
+  store_->Put(cf, path, value);
+}
+
+std::optional<int> SyscallHandler::Open(const char* pathname, int flags) {
+  assert(pathname && *pathname);
+  const string_view path = pathname;
+
+  if (!IsKnownExtension(path))
+    return {};
+  if (!regex_match(path.cbegin(), path.cend(), re_path_to_known_file))
+    throw invalid_argument("unexpected pathname");
+
+  if (!(flags & O_CREAT) && !Exists(path)) {
+    errno = ENOENT;
+    return -1;
+  }
+
+  return RedirectOpenFile(path, this);
+}
+
+std::optional<int> SyscallHandler::Access(const char* pathname) const {
+  assert(pathname && *pathname);
+
+  string path = pathname;
+  const bool known_ext = IsKnownExtension(path);
+
+  if (known_ext) {
+    if (!regex_match(path.cbegin(), path.cend(), re_path_to_known_file))
+      throw invalid_argument("unexpected pathname");
+  } else if (regex_match(path.cbegin(), path.cend(), re_folder)) {
+    // It might be a db folder. Check if db.opt exists.
+    path += "/db.opt";
+  } else
+    return {};
+
+  if (Exists(path))
+    return 0;
+  if (!known_ext)
+    return {};
+
+  errno = ENOENT;
+  return -1;
+}
+
+bool SyscallHandler::Exists(std::string_view path) const {
+  const string_view cf = GetCf(path);
+  const lock_guard lock(mutex_);
+  return store_->Get(cf, path).has_value();
+}

--- a/src/syscall_handler.cc
+++ b/src/syscall_handler.cc
@@ -193,6 +193,12 @@ std::optional<int> SyscallHandler::Open(const char* pathname, int flags) {
     return -1;
   }
 
+  // don't create .frm file if db doesn't exist
+  if (StrEndsWith(path, ".frm") && !Exists(string(path, 0, path.rfind('/') + 1) + "db.opt")) {
+    errno = ENOENT;
+    return -1;
+  }
+
   return RedirectOpenFile(path, this);
 }
 

--- a/src/syscall_handler.h
+++ b/src/syscall_handler.h
@@ -51,6 +51,7 @@ class SyscallHandler final {
  private:
   std::optional<int> Open(const char* pathname, int flags);
   std::optional<int> Access(const char* pathname) const;
+  std::optional<int> Rename(const char* oldpath, const char* newpath);
   std::optional<int> Unlink(const char* pathname);
   bool Exists(std::string_view path) const;
 

--- a/src/syscall_handler.h
+++ b/src/syscall_handler.h
@@ -40,6 +40,9 @@ class SyscallHandler final {
   // Returns an int if the syscall was handled; otherwise, returns none.
   std::optional<int> Syscall(long number, long x1, long x2);
 
+  // Returns the directory contents backed by the store.
+  std::vector<std::string> Dir(std::string_view pathname) const;
+
   // These are called for open files backed by the store.
   size_t Read(std::string_view path, void* buf, size_t count, size_t offset) const;
   void Write(std::string_view path, std::string_view buf, size_t offset);

--- a/src/syscall_handler.h
+++ b/src/syscall_handler.h
@@ -46,10 +46,12 @@ class SyscallHandler final {
   // These are called for open files backed by the store.
   size_t Read(std::string_view path, void* buf, size_t count, size_t offset) const;
   void Write(std::string_view path, std::string_view buf, size_t offset);
+  size_t Size(std::string_view path) const;
 
  private:
   std::optional<int> Open(const char* pathname, int flags);
   std::optional<int> Access(const char* pathname) const;
+  std::optional<int> Unlink(const char* pathname);
   bool Exists(std::string_view path) const;
 
   StorePtr store_;

--- a/src/syscall_handler.h
+++ b/src/syscall_handler.h
@@ -1,0 +1,56 @@
+/* Copyright (c) Edgeless Systems GmbH
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA */
+
+#pragma once
+
+#include <mutex>
+#include <optional>
+#include <string_view>
+
+#include "store.h"
+
+namespace edb {
+
+constexpr std::string_view kCfNameFrm = "edg_frm_cf";
+constexpr std::string_view kCfNameDb = "edg_db_cf";
+
+/*
+SyscallHandler intercepts filesystem calls and redirects .frm and db.opt files to the store.
+
+MariaDB would usually write different types of files to its data directory. We mount this directory
+in memfs for security, excluding the encrypted RocksDB files. However, .frm and db.opt files need
+to be persistent. To achieve this, we intercept access to them and store them in RocksDB.
+*/
+class SyscallHandler final {
+ public:
+  explicit SyscallHandler(StorePtr store);
+
+  // Returns an int if the syscall was handled; otherwise, returns none.
+  std::optional<int> Syscall(long number, long x1, long x2);
+
+  // These are called for open files backed by the store.
+  size_t Read(std::string_view path, void* buf, size_t count, size_t offset) const;
+  void Write(std::string_view path, std::string_view buf, size_t offset);
+
+ private:
+  std::optional<int> Open(const char* pathname, int flags);
+  std::optional<int> Access(const char* pathname) const;
+  bool Exists(std::string_view path) const;
+
+  StorePtr store_;
+  mutable std::mutex mutex_;
+};
+
+}  // namespace edb

--- a/src/syscall_handler.h
+++ b/src/syscall_handler.h
@@ -50,6 +50,7 @@ class SyscallHandler final {
 
  private:
   std::optional<int> Open(const char* pathname, int flags);
+  std::optional<int> Stat(const char* pathname, long statbuf) const;
   std::optional<int> Access(const char* pathname) const;
   std::optional<int> Rename(const char* oldpath, const char* newpath);
   std::optional<int> Unlink(const char* pathname);

--- a/src/syscall_hook.cc
+++ b/src/syscall_hook.cc
@@ -1,0 +1,44 @@
+/* Copyright (c) Edgeless Systems GmbH
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA */
+
+#include <cassert>
+#include <exception>
+#include <memory>
+
+#include "oe_internal.h"
+#include "rocksdb.h"
+#include "syscall_handler.h"
+
+using namespace std;
+using namespace edb;
+
+static SyscallHandler handler(make_shared<RocksDB>());
+
+extern "C" oe_result_t edgeless_syscall_hook(long number, long x1, long x2, long /*x3*/, long /*x4*/, long /*x5*/, long /*x6*/, long* ret) {
+  assert(ret);
+
+  try {
+    const auto res = handler.Syscall(number, x1, x2);
+    if (!res)
+      return OE_UNEXPECTED;
+    *ret = *res;
+  } catch (const exception& ex) {
+    oe_log(OE_LOG_LEVEL_ERROR, "syscall_hook %ld: %s\n", number, ex.what());
+    *ret = -1;
+    errno = EIO;
+  }
+
+  return OE_OK;
+}

--- a/src/syscall_hook.cc
+++ b/src/syscall_hook.cc
@@ -13,7 +13,13 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA */
 
+typedef unsigned int uint;
+typedef unsigned long myf;
+
+#include <my_dir.h>
+
 #include <cassert>
+#include <cstring>
 #include <exception>
 #include <memory>
 
@@ -41,4 +47,45 @@ extern "C" oe_result_t edgeless_syscall_hook(long number, long x1, long x2, long
   }
 
   return OE_OK;
+}
+
+// To avoid implementing redirections for syscalls on directories, we replaced a few relevant my_dir calls with edgeless_my_dir.
+MY_DIR* edgeless_my_dir(const char* path, myf /*MyFlags*/) {
+  // dummy stat for all paths is sufficient to satisfy MariaDB
+  static MY_STAT mystat = [] {
+    MY_STAT mystat{};
+    mystat.st_mode = MY_S_IFDIR;
+    return mystat;
+  }();
+
+  try {
+    const auto subpaths = handler.Dir(path);
+    auto entries = make_unique<fileinfo[]>(subpaths.size());  // NOLINT
+    auto dir = make_unique<MY_DIR>();
+    dir->number_of_files = subpaths.size();
+
+    // fill entries
+    for (size_t i = 0; i < subpaths.size(); ++i) {
+      const auto& subpath = subpaths[i];
+      auto& entry = entries[i];
+      entry.mystat = &mystat;
+      entry.name = new char[subpath.size() + 1]();
+      memcpy(entry.name, subpath.data(), subpath.size());
+    }
+
+    dir->dir_entry = entries.release();
+    return dir.release();
+  } catch (const exception& ex) {
+    oe_log(OE_LOG_LEVEL_ERROR, "my_dir: %s\n", ex.what());
+    return nullptr;
+  }
+}
+
+void edgeless_my_dirend(MY_DIR* buffer) {
+  assert(buffer);
+  assert(buffer->dir_entry);
+  for (size_t i = 0; i < buffer->number_of_files; ++i)
+    delete[] buffer->dir_entry[i].name;
+  delete[] buffer->dir_entry;
+  delete buffer;
 }

--- a/src/syscall_test.cc
+++ b/src/syscall_test.cc
@@ -152,8 +152,11 @@ static void TestDir() {
   const SyscallHandler handler(store);
 
   ASSERT(vector<string>{"mydb"} == handler.Dir("."));
+  ASSERT(vector<string>{"mydb"} == handler.Dir("/data/"));
   ASSERT((vector<string>{"bar.frm", "foo.frm"}) == handler.Dir("./mydb"));
   ASSERT((vector<string>{"bar.frm", "foo.frm"}) == handler.Dir("./mydb/"));
+  ASSERT((vector<string>{"bar.frm", "foo.frm"}) == handler.Dir("/data/mydb"));
+  ASSERT((vector<string>{"bar.frm", "foo.frm"}) == handler.Dir("/data/mydb/"));
   ASSERT(handler.Dir("./otherdb").empty());
 }
 

--- a/src/syscall_test.cc
+++ b/src/syscall_test.cc
@@ -84,6 +84,7 @@ static void TestAccess() {
   // access existing files succeeds
   ASSERT(0 == my_access("./mydb/db.opt"));
   ASSERT(0 == my_access("./mydb/mytab.frm"));
+  ASSERT(0 == my_access("mydb/db.opt"));
 
   // access nonexistent files fails
   errno = 0;

--- a/src/syscall_test.cc
+++ b/src/syscall_test.cc
@@ -148,6 +148,20 @@ static void TestOpenError() {
   ASSERT(!my_open("./foo/bar.baz"));
 }
 
+static void TestRename() {
+  const auto store = make_shared<FakeStore>();
+  store->Put(kCfNameFrm, "./mydb/oldname.frm", "foo");
+  SyscallHandler handler(store);
+
+  const auto my_rename = [&handler](const char* oldpath, const char* newpath) {
+    return handler.Syscall(SYS_rename, reinterpret_cast<long>(oldpath), reinterpret_cast<long>(newpath));
+  };
+
+  ASSERT(0 == my_rename("./mydb/oldname.frm", "./mydb/newname.frm"));
+  ASSERT(!store->Get(kCfNameFrm, "./mydb/oldname.frm"));
+  ASSERT("foo" == store->Get(kCfNameFrm, "./mydb/newname.frm"));
+}
+
 static void TestUnlink() {
   const auto store = make_shared<FakeStore>();
   store->Put(kCfNameDb, "./mydb/db.opt", {});
@@ -184,6 +198,7 @@ int main() {
   TestAccess();
   TestFile();
   TestOpenError();
+  TestRename();
   TestUnlink();
   TestDir();
   cout << "pass\n";

--- a/src/syscall_test.cc
+++ b/src/syscall_test.cc
@@ -148,6 +148,11 @@ static void TestOpenError() {
 
   // open other file is not handled
   ASSERT(!my_open("./foo/bar.baz"));
+
+  // create frm without existing db.opt fails
+  errno = 0;
+  ASSERT(-1 == my_open("./foo/bar.frm", O_CREAT));
+  ASSERT(ENOENT == errno);
 }
 
 static void TestStat() {

--- a/src/syscall_test.cc
+++ b/src/syscall_test.cc
@@ -1,0 +1,157 @@
+/* Copyright (c) Edgeless Systems GmbH
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA */
+
+#include <fcntl.h>
+#include <sys/syscall.h>
+
+#include <cstdarg>
+#include <functional>
+#include <iostream>
+#include <map>
+
+#include "oe_internal.h"
+#include "syscall_handler.h"
+
+#define ASSERT(x) /*NOLINT*/                                       \
+  if (!(x)) {                                                      \
+    std::cout << __FILE__ << ':' << __LINE__ << ' ' << #x << '\n'; \
+    abort();                                                       \
+  }
+
+using namespace std;
+using namespace edb;
+
+namespace edb {
+// will be overridden for testing
+extern function<decltype(oe_fdtable_assign)> fdtable_assign;
+}  // namespace edb
+
+namespace {
+struct FakeStore : Store {
+  std::optional<std::string> Get(std::string_view column_family, std::string_view key) const override {
+    const auto it1 = data.find(column_family);
+    if (it1 == data.cend())
+      return {};
+    const auto it2 = it1->second.find(key);
+    if (it2 == it1->second.cend())
+      return {};
+    return it2->second;
+  }
+
+  void Put(std::string_view column_family, std::string_view key, std::string_view value) override {
+    data[string(column_family)][string(key)] = value;
+  }
+
+  map<string, map<string, string, less<>>, less<>> data;
+};
+}  // namespace
+
+static void TestAccess() {
+  const auto store = make_shared<FakeStore>();
+  store->Put(kCfNameDb, "./mydb/db.opt", {});
+  store->Put(kCfNameFrm, "./mydb/mytab.frm", {});
+  SyscallHandler handler(store);
+
+  const auto my_access = [&handler](const char* path) {
+    return handler.Syscall(SYS_access, reinterpret_cast<long>(path), 0);
+  };
+
+  // access existing files succeeds
+  ASSERT(0 == my_access("./mydb/db.opt"));
+  ASSERT(0 == my_access("./mydb/mytab.frm"));
+
+  // access nonexistent files fails
+  errno = 0;
+  ASSERT(-1 == my_access("./otherdb/db.opt"));
+  ASSERT(ENOENT == errno);
+  errno = 0;
+  ASSERT(-1 == my_access("./mydb/othertab.frm"));
+  ASSERT(ENOENT == errno);
+
+  // access folder of existing db succeeds
+  ASSERT(0 == my_access("./mydb"));
+
+  // access other folder is not handled
+  ASSERT(!my_access("./otherdb"));
+}
+
+static void TestFile() {
+  const auto path = "./foo/db.opt";
+  const string_view in = "bar";
+
+  const auto store = make_shared<FakeStore>();
+  SyscallHandler handler(store);
+
+  oe_fd_t* file = nullptr;
+  fdtable_assign = [&file](oe_fd_t* desc) {
+    file = desc;
+    return 2;
+  };
+
+  // write the file
+  ASSERT(2 == handler.Syscall(SYS_open, reinterpret_cast<long>(path), O_CREAT));
+  ASSERT(3 == file->ops.fd.write(file, in.data(), in.size()));
+  ASSERT(0 == file->ops.fd.close(file));
+
+  // read the file
+  ASSERT(2 == handler.Syscall(SYS_open, reinterpret_cast<long>(path), 0));
+  string out(in.size(), '\0');
+  ASSERT(3 == file->ops.fd.read(file, out.data(), out.size()));
+  ASSERT(0 == file->ops.fd.close(file));
+  ASSERT(in == out);
+}
+
+static void TestOpenError() {
+  const auto store = make_shared<FakeStore>();
+  SyscallHandler handler(store);
+
+  const auto my_open = [&handler](const char* path, int flags = 0) {
+    return handler.Syscall(SYS_open, reinterpret_cast<long>(path), flags);
+  };
+
+  // open nonexistent frm fails
+  errno = 0;
+  ASSERT(-1 == my_open("./foo/bar.frm"));
+  ASSERT(ENOENT == errno);
+
+  // open nonexistent opt fails
+  errno = 0;
+  ASSERT(-1 == my_open("./foo/db.opt"));
+  ASSERT(ENOENT == errno);
+
+  // open other file is not handled
+  ASSERT(!my_open("./foo/bar.baz"));
+}
+
+int main() {
+  TestAccess();
+  TestFile();
+  TestOpenError();
+  cout << "pass\n";
+}
+
+// We must define this func to satisfy the linker. It won't be called.
+int oe_fdtable_assign(oe_fd_t* /*desc*/) {
+  ASSERT(false);
+}
+
+// We must define this func to satisfy the linker.
+oe_result_t oe_log(oe_log_level_t /*level*/, const char* fmt, ...) {
+  va_list valist;
+  va_start(valist, fmt);
+  vprintf(fmt, valist);
+  va_end(valist);
+  return OE_OK;
+}


### PR DESCRIPTION
Reverts most changes regarding frm/opt files within edgeless-mariadb and hooks file syscalls instead.
Commit history should help navigate the PR.