### PR TITLE
integration test: wait for process termination to avoid "address already in use"

### DIFF
--- a/edb/server/server.go
+++ b/edb/server/server.go
@@ -109,7 +109,7 @@ func RunServer(mux *http.ServeMux, address string, tlsConfig *tls.Config) {
 	}
 
 	rt.Log.Println("HTTP REST API listening on", address)
-	rt.Log.Println(server.ListenAndServeTLS("", ""))
+	rt.Log.Fatalln(server.ListenAndServeTLS("", ""))
 }
 
 func writeJSON(w http.ResponseWriter, v interface{}) {


### PR DESCRIPTION
This is an attempt to fix (one kind of) the occasional e2e failures.