### PR TITLE
copy era config to final docker image

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -11,6 +11,12 @@ Add `--build-arg heapsize=x` where x is the desired enclave heap size in MB. By 
 
 Add `--build-arg production=ON` to build a production enclave. By default, a debug enclave is built.
 
+Get the [era](https://github.com/edgelesssys/era) configuration:
+
+```sh
+docker run --rm --entrypoint cat edb edgelessdb-sgx.json > edgelessdb-sgx.json
+```
+
 ## Run the Docker image
 You can run EdgelessDB in simulation mode on any system:
 ```sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN apt update && apt install -y gnupg libcurl4 wget \
   libsgx-qe3-logic=$DCAP_VERSION \
   libsgx-urts=$PSW_VERSION \
   && apt install -d az-dcap-client libsgx-dcap-default-qpl=$DCAP_VERSION
-COPY --from=build /edbbuild/edb /edbbuild/edb-enclave.signed /edgelessdb/src/entry.sh /
+COPY --from=build /edbbuild/edb /edbbuild/edb-enclave.signed /edbbuild/edgelessdb-sgx.json /edgelessdb/src/entry.sh /
 COPY --from=build /opt/edgelessrt/bin/erthost /opt/edgelessrt/bin/
 ENV PATH=${PATH}:/opt/edgelessrt/bin AZDCAP_DEBUG_LOG_LEVEL=error
 ENTRYPOINT ["/entry.sh"]


### PR DESCRIPTION
Make `edgelessdb-sgx.json` available in the docker image so that you can obtain it at any time.