### PR TITLE
clean up frm file on mismatch

### DIFF
--- a/src/syscall_handler.cc
+++ b/src/syscall_handler.cc
@@ -292,7 +292,7 @@ std::optional<int> SyscallHandler::Rename(const char* oldpath, const char* newpa
 std::optional<int> SyscallHandler::Unlink(const char* pathname) {
   assert(pathname && *pathname);
 
-  const string_view path = pathname;
+  const string path = NormalizePath(pathname);
   if (!IsKnownExtension(path))
     return {};
 


### PR DESCRIPTION
If during the creation of a table the process crashes between creating the .frm file and registering it in RocksDB, it will fail on start due to this inconsistency.

I guess this is desired behavior in MariaDB. They don't want to delete any (meta)data automatically and the user can easily recover it manually by deleting the .frm file.

With EDB, this isn't possible because .frm files are redirected to RocksDB storage. Instead of failing, it will now clean up the .frm file. I think this is good enough for our use case. (Actual fix is in the submodule change.)

@m1ghtym0 As you've dealt with .frm file handling in the past, please think about whether you see any issues with this solution.