### PR TITLE
Entry.sh doesn't fail if directory already exists

### DIFF
--- a/src/entry.sh
+++ b/src/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-mkdir /dev/sgx
+mkdir -p /dev/sgx
 ln -s /dev/sgx_enclave /dev/sgx/enclave
 
 if [ -n "${PCCS_ADDR}" ]; then

--- a/src/entry.sh
+++ b/src/entry.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-if [ ! -d /dev/sgx ]; then
-	mkdir -p /dev/sgx
+mkdir -p /dev/sgx
+if [ ! -L /dev/sgx/enclave ]; then
 	ln -s /dev/sgx_enclave /dev/sgx/enclave
 fi
 

--- a/src/entry.sh
+++ b/src/entry.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 set -e
 
-mkdir -p /dev/sgx
-ln -s /dev/sgx_enclave /dev/sgx/enclave
+if [ ! -d /dev/sgx ]; then
+	mkdir -p /dev/sgx
+	ln -s /dev/sgx_enclave /dev/sgx/enclave
+fi
 
 if [ -n "${PCCS_ADDR}" ]; then
 	PCCS_URL=https://${PCCS_ADDR}/sgx/certification/v3/


### PR DESCRIPTION
When running on Docker @ Ubuntu the container will always fail as the directory already exists. 
Using docker-compose with the service :
```
  edgelessdb:
    privileged: true
    volumes:
      - /dev/sgx:/dev/sgx
```

I guess this is partly docker composes fault as it creates the folder on a mounted volume.
The -p flag ensures the mkdir doesn't report a failure if the directory already exists.